### PR TITLE
Enable locals in main

### DIFF
--- a/src/main/antlr4/MiniJava.g4
+++ b/src/main/antlr4/MiniJava.g4
@@ -21,6 +21,7 @@ mainClass
     : 'public' 'class' Identifier '{'
         'public' 'static' 'void' 'main'
         '(' 'String' '[' ']' Identifier ')' '{'
+            varDeclaration*
             statement*
         '}'
       '}'

--- a/src/main/java/ast/MainClass.java
+++ b/src/main/java/ast/MainClass.java
@@ -9,8 +9,10 @@ import java.util.List;
  */
 public record MainClass(String name,
                         String argName,
+                        List<VarDecl> locals,
                         List<Statement> statements) implements Node {
     public MainClass {
+        locals = locals == null ? List.of() : List.copyOf(locals);
         statements = statements == null ? List.of() : List.copyOf(statements);
     }
 }

--- a/src/main/java/cgen/CGenerator.java
+++ b/src/main/java/cgen/CGenerator.java
@@ -55,6 +55,9 @@ public class CGenerator {
      
         emit("int main() {");
         indent++;
+        for (VarDecl v : program.mainClass().locals()) {
+            emit(mapType(v.type()) + " " + v.name() + ";");
+        }
         for (Statement s : program.mainClass().statements()) {
             visitStatement(s);
         }

--- a/src/main/java/cli/AstBuilder.java
+++ b/src/main/java/cli/AstBuilder.java
@@ -41,8 +41,9 @@ public class AstBuilder extends MiniJavaBaseVisitor<Object> {
     @Override public MainClass visitMainClass(MiniJavaParser.MainClassContext ctx) {
         String className = ctx.Identifier(0).getText();
         String argName   = ctx.Identifier(1).getText();
+        List<VarDecl> locals = visitAll(ctx.varDeclaration(), VarDecl.class);
         List<Statement> stmts = visitAll(ctx.statement(), Statement.class);
-        return new MainClass(className, argName, stmts);
+        return new MainClass(className, argName, locals, stmts);
     }
 
     /* classDeclaration */

--- a/src/main/java/cli/AstPrinter.java
+++ b/src/main/java/cli/AstPrinter.java
@@ -73,6 +73,10 @@ public class AstPrinter {
     private void visitMainClass(MainClass node) {
         println("MainClass " + node.name() + " with arg " + node.argName());
         indent();
+        println("locals:");
+        indent();
+        node.locals().forEach(this::visit);
+        unindent();
         println("body:");
         indent();
         node.statements().forEach(this::visit);

--- a/src/main/java/sem/SemanticAnalyzer.java
+++ b/src/main/java/sem/SemanticAnalyzer.java
@@ -47,7 +47,12 @@ public class SemanticAnalyzer {
         Deque<Map<String, Type>> scopes = new ArrayDeque<>();
         pushScope(scopes);
         scopes.peek().put(main.argName(), new Type("String", true));
+        pushScope(scopes);
+        for (VarDecl v : main.locals()) {
+            declareVar(scopes, v);
+        }
         analyzeStatements(main.statements(), scopes, classes, null);
+        popScope(scopes);
         popScope(scopes);
     }
 


### PR DESCRIPTION
## Summary
- allow `varDeclaration*` in `mainClass` grammar
- extend `MainClass` AST to store local variables
- parse locals in `AstBuilder` and print them in `AstPrinter`
- declare locals during semantic analysis
- emit declarations in generated C `main`

## Testing
- `javac -d build @sources.txt` *(fails: cannot find symbol `TerminalNode`)*

------
https://chatgpt.com/codex/tasks/task_e_6872cd17eee0832a91704af298796817